### PR TITLE
fix: Add allowedPostUpgradeCommands to Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -99,6 +99,9 @@
       "automerge": true
     }
   ],
+  "allowedPostUpgradeCommands": [
+    "^uv lock$"
+  ],
   "postUpgradeTasks": {
     "commands": [
       "uv lock"


### PR DESCRIPTION
## Summary
- Add `allowedPostUpgradeCommands` setting to Renovate configuration to allow `uv lock` command execution
- Resolves the artifact update problem where Renovate was unable to execute the uv lock command as a post-upgrade task

## Background
Renovate was failing with the following warning:
```
WARN: Post-upgrade task did not match any on allowedCommands list
Post-upgrade command 'uv lock' has not been added to the allowed list in allowedCommands
```

This occurred because Renovate requires post-upgrade commands to be explicitly whitelisted in the `allowedPostUpgradeCommands` configuration for security reasons.

## Changes
- Added `allowedPostUpgradeCommands` array with regex pattern `^uv lock$` to renovate.json

## Test plan
- [x] Configuration syntax is valid JSON
- [ ] Verify next Renovate run executes `uv lock` successfully without warnings
- [ ] Confirm `uv.lock` file is properly updated in Renovate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)