### PR TITLE
feat: Add shallow clone support for large repositories

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -8,6 +8,10 @@
   "auto_stash": false,
   "sync_only": false,
   "log_file": "~/logs/repo-sync.log",
+  "clone_timeout": 600,
+  "shallow_clone": false,
+  "clone_depth": 1,
+  "large_repos": [],
   "vscode_templates": {
     "windows": "./vscode-templates/windows",
     "linux": "./vscode-templates/linux",

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -119,7 +119,28 @@ export GITHUB_TOKEN=your_personal_access_token
   "skip_uv_install": false,
   "auto_stash": false,
   "sync_only": false,
-  "log_file": "/path/to/logs/repo-sync.log"
+  "log_file": "/path/to/logs/repo-sync.log",
+  "clone_timeout": 600,
+  "shallow_clone": false,
+  "clone_depth": 1,
+  "large_repos": ["PowerToys", "other-large-repo"]
+}
+```
+
+#### 大きなリポジトリの設定
+
+大きなリポジトリ（PowerToysなど）をクローンする場合、以下の設定を調整できます：
+
+- `clone_timeout`: クローン操作のタイムアウト（秒）。デフォルトは600秒（10分）
+- `shallow_clone`: すべてのリポジトリで浅いクローンを使用するか（デフォルト: false）
+- `clone_depth`: 浅いクローンの深さ（デフォルト: 1）
+- `large_repos`: 自動的に浅いクローンを使用するリポジトリのリスト
+
+**例: PowerToysの設定**
+```json
+{
+  "clone_timeout": 1200,
+  "large_repos": ["PowerToys"]
 }
 ```
 


### PR DESCRIPTION
## Summary

PowerToysのような大きなリポジトリをクローンする際のタイムアウト問題を解決するため、shallow cloneのサポートを追加しました。

## Changes

### 新しい設定オプション
- `clone_timeout`: クローン操作のタイムアウト（秒）、デフォルト600秒
- `shallow_clone`: すべてのリポジトリでshallow cloneを使用するか
- `clone_depth`: shallow cloneの深さ、デフォルト1
- `large_repos`: 自動的にshallow cloneを使用するリポジトリのリスト

### コード変更
- `git_operations.py`: `_clone_repository()`関数にshallow cloneとタイムアウト設定のサポートを追加
- `GitOperations.clone_repository()`メソッドも同様に更新
- タイムアウトエラー時の適切なエラーメッセージとガイダンスを追加

### ドキュメント
- `config.json.template`: 新しい設定オプションを追加
- `docs/setup-guide.md`: 大きなリポジトリの設定方法を説明

### テスト
7つの新しいテストケースを追加：
- Shallow clone設定のテスト
- カスタムタイムアウト設定のテスト
- Large repos設定のテスト
- タイムアウトエラー処理のテスト
- カスタムclone depth設定のテスト

## Test Results

✅ All 30 tests passed
✅ Ruff lint: Passed
✅ Ruff format: Passed
✅ MyPy type check: Passed
✅ Bandit security check: Passed
✅ Pre-commit hooks: All passed

## Verification

PowerToysリポジトリで実際にテストし、shallow cloneが正常に動作することを確認しました：
```
📥 PowerToys: クローン中（shallow clone, depth=1）...
✅ PowerToys: クローン完了（shallow clone）
```

## Breaking Changes

なし。既存の動作には影響しません。新しい設定オプションはすべてオプトイン方式です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)